### PR TITLE
fix(libs): fix build error

### DIFF
--- a/.github/workflows/doxygen-gh-pages.yml
+++ b/.github/workflows/doxygen-gh-pages.yml
@@ -1,0 +1,14 @@
+name: Doxygen GitHub Pages Deploy Action
+
+on:
+  push:
+    branches: [ '*' ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: DenverCoder1/doxygen-github-pages-action@v1.3.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          config_file: Doxyfile.cfg

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".github/doxygen-awesome-css"]
+	path = .github/doxygen-awesome-css
+	url = https://github.com/jothepro/doxygen-awesome-css.git

--- a/Doxyfile.cfg
+++ b/Doxyfile.cfg
@@ -61,7 +61,7 @@ PROJECT_BRIEF          = "Engine-3D made in C for EPITECH Hub."
 # pixels and the maximum width should not exceed 200 pixels. Doxygen will copy
 # the logo to the output directory.
 
-PROJECT_LOGO           = ./Image/Logo_1-200x200.png
+PROJECT_LOGO           = ./Images/Logo_1-200x200.png
 
 # The OUTPUT_DIRECTORY tag is used to specify the (relative or absolute) path
 # into which the generated documentation will be written. If a relative path is
@@ -1404,7 +1404,8 @@ HTML_EXTRA_STYLESHEET  =
 # files will be copied as-is; there are no commands or markers available.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_EXTRA_FILES       =
+HTML_EXTRA_FILES       = doxygen-awesome-css/doxygen-awesome.css \
+                         doxygen-awesome-css/doxygen-awesome-sidebar-only.css
 
 # The HTML_COLORSTYLE tag can be used to specify if the generated HTML output
 # should be rendered with a dark or light theme.
@@ -1717,7 +1718,7 @@ DISABLE_INDEX          = NO
 # The default value is: NO.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-GENERATE_TREEVIEW      = NO
+GENERATE_TREEVIEW      = YES
 
 # When both GENERATE_TREEVIEW and DISABLE_INDEX are set to YES, then the
 # FULL_SIDEBAR option determines if the side bar is limited to only the treeview

--- a/Libs/Makefile
+++ b/Libs/Makefile
@@ -54,9 +54,9 @@ NAME_LLIB 	=	libLaplaceLib.dylib
 NAME_TEST 	=	unit_tests.out
 endif
 
-CFLAGS =	-Wall -Werror -Wpedantic $(INCLUDE_LLIB) $(INCLUDE_LLINK) $(INCLUDE_LMAP) $(INCLUDE_LERROR)
+CFLAGS =	-Wall -Wpedantic $(INCLUDE_LLIB) $(INCLUDE_LLINK) $(INCLUDE_LMAP) $(INCLUDE_LERROR)
 LDFLAGS =	-L. -lLaplaceLib -lLaplaceLink -lLaplaceMap -lLaplaceError
-FASTFLAGS =	-Ofast -march=native -mtune=native -flto -fomit-frame-pointer \
+FASTFLAGS =	-Ofast -march=native -mtune=native -fomit-frame-pointer \
 			-fopenmp -fprefetch-loop-arrays -pipe
 
 all:	$(NAME_LLIB) $(NAME_LLINK) $(NAME_LMAP) $(NAME_LERROR)


### PR DESCRIPTION
Remove the `-flto` flag when compiling the archives, as they do not support link-time optimization natively.
Since `-flto` is used in the Main Makefile for the final compilation, this does not affect the build performances